### PR TITLE
IPFS 170

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # go-ipfs-datadog-plugin
 
-Datadog tracing plugin for go-ipfs.
-
+This repository contains the following `go-ipfs` plugins:
+- Datadog tracing plugin configures the Datadog tracer to collect the traces and relay them to the agent. `go-ipfs` tracing instrumentation is partial at the moment but should improve over time.
+- Datadog logger plugin allows users to set log levels for each `go-ipfs` subsystem. 
 
 ## Caveats
-
-- This plugin doesn't implement any tracing, it simply configures the Datadog tracer to collect the traces and relay them to the agent. `go-ipfs` tracing instrumentation is partial at the moment but should improve over time.
 
 - Plugins only work on Linux and MacOS at the moment. You can track the progress of this issue here: https://github.com/golang/go/issues/19282
 
@@ -36,6 +35,55 @@ To update the go-ipfs, run:
 
 Copy `datadog-plugin.so` to `$IPFS_DIR/plugins/datadog-plugin.so` (or run `make install` if you are installing locally)
 
+### Configuration
+
+Define plugin configurations variables in the ipfs config file.
+
+- datadog-logger config:
+```
+{
+...
+"Plugins": {
+    "Plugins": {
+    ...
+      "datadog-logger": {
+        "Config": {
+            "Levels": {
+                "fatal": ["system1", "system2", ...],
+                "error": [...]
+                "warn": [...]
+                ...
+            },
+            "DefaultLevel": "info"
+        },
+        "Disabled": false
+      },
+    ...
+    }
+  },
+...
+}
+```
+
+- datadog-tracer config:
+```
+{
+...
+"Plugins": {
+    "Plugins": {
+      ...
+      "datadog-tracer": {
+        "Config": {
+            "TracerName": "go-ipfs-custom"
+        },
+        "Disabled": false
+      }
+      ...
+    }
+  },
+...
+}
+```
 
 ## References
 

--- a/plugin/datadog.go
+++ b/plugin/datadog.go
@@ -22,8 +22,6 @@ var _ plugin.PluginTracer = &DatadogPlugin{}
 
 var tracerName = "go-ipfs"
 
-const tracerNameKey = "IpfsTracerName"
-
 // "Plugins": {
 //	"datadog": {
 //	  "Config": {

--- a/plugin/datadog.go
+++ b/plugin/datadog.go
@@ -15,6 +15,7 @@ var log = logging.Logger("datadog")
 
 var Plugins = []plugin.Plugin{
 	&DatadogPlugin{},
+	&LoggerPlugin{},
 }
 
 var _ plugin.PluginTracer = &DatadogPlugin{}

--- a/plugin/datadog.go
+++ b/plugin/datadog.go
@@ -22,22 +22,14 @@ var _ plugin.PluginTracer = &DatadogPlugin{}
 
 var tracerName = "go-ipfs"
 
-// "Plugins": {
-//	"datadog": {
-//	  "Config": {
-//		"IpfsTracerName": "go-ipfs"
-//	  },
-//	  "Disabled": false
-//	}
-// }
 type datadogConfig struct {
-	IpfsTracerName string
+	TracerName string
 }
 
 type DatadogPlugin struct{}
 
 func (d *DatadogPlugin) Name() string {
-	return "datadog"
+	return "datadog-tracer"
 }
 
 func (d *DatadogPlugin) Version() string {
@@ -56,8 +48,8 @@ func (d *DatadogPlugin) Init(env *plugin.Environment) error {
 	if err := json.Unmarshal(bytes, &config); err != nil {
 		return err
 	}
-	if config.IpfsTracerName != "" {
-		tracerName = config.IpfsTracerName
+	if config.TracerName != "" {
+		tracerName = config.TracerName
 	}
 	return nil
 }

--- a/plugin/logger.go
+++ b/plugin/logger.go
@@ -1,0 +1,49 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ipfs/go-ipfs/plugin"
+	logging "github.com/ipfs/go-log"
+)
+
+// LoggerPlugin controls which ipfs subsystems loggers are enabled
+// These subsystems will be defined in env variable:
+// eg: LOGGER_SUBSYSTEMS_WHITELIST = "dht,relay,corerepo"
+type LoggerPlugin struct{}
+
+var _ plugin.Plugin = &LoggerPlugin{}
+
+const loggerSubsystemsEnv = "LOGGER_SUBSYSTEMS_WHITELIST"
+
+func (l LoggerPlugin) Name() string {
+	return "logger"
+}
+
+func (l LoggerPlugin) Version() string {
+	return "0.0.1"
+}
+
+// Set log levels for each subsystem
+// info level for whitelisted subsystem
+// fatal level for all others
+func (l LoggerPlugin) Init(env *plugin.Environment) error {
+	whitelistedSubsystems := os.Getenv(loggerSubsystemsEnv)
+	// If no subsystems given, exit with default settings
+	if whitelistedSubsystems == "" {
+		return nil
+	}
+
+	logging.SetAllLoggers(logging.LevelFatal)
+	for _, s := range strings.Split(whitelistedSubsystems, ",") {
+		subsystem := strings.TrimSpace(s)
+		err := logging.SetLogLevel(subsystem, "info")
+		if err != nil {
+			fmt.Printf("[Warning] Set log level failed for subsystem: %s. Error: %s", subsystem, err.Error())
+		}
+	}
+
+	return nil
+}

--- a/plugin/logger.go
+++ b/plugin/logger.go
@@ -9,10 +9,6 @@ import (
 	"github.com/ipfs/go-ipfs/plugin"
 )
 
-// LoggerPlugin controls which ipfs subsystems loggers are enabled
-// These subsystems are defined in ipfs config Plugins
-type LoggerPlugin struct{}
-
 var _ plugin.Plugin = &LoggerPlugin{}
 
 // "Plugins": {
@@ -31,6 +27,10 @@ type loggerConfig struct {
 	// log level for the whitelisted subsystems
 	LogLevel string
 }
+
+// LoggerPlugin controls which ipfs subsystems loggers are enabled
+// These subsystems are defined in ipfs config Plugins
+type LoggerPlugin struct{}
 
 func (l LoggerPlugin) Name() string {
 	return "logger"


### PR DESCRIPTION
Added feature for [#170](https://github.com/INFURA/ipfs/issues/170)
> The goal here is to extend https://github.com/INFURA/go-ipfs-datadog-plugin to collect and send logs to datadog. Bonus point if we can configure the list of go-ipfs subsystem we care about.

- load plugins with values from ipfs config file system   
- define log levels for each `go-ipfs` subsystem
- fail with error if invalid config values given