### PR TITLE
Add a metrics plugin to export OpenCensus metrics to datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains the following `go-ipfs` plugins:
 - Datadog tracing plugin configures the Datadog tracer to collect the traces and relay them to the agent. `go-ipfs` tracing instrumentation is partial at the moment but should improve over time.
 - Datadog logger plugin allows users to set log levels for each `go-ipfs` subsystem. 
+- Datadog metrics plugin configure a datadog exporter for OpenCensus metrics.
 
 ## Caveats
 
@@ -88,7 +89,6 @@ Define plugin configurations variables in the ipfs config file.
 ## References
 
 - Boilerplate for this repo is based on https://github.com/ipfs/go-ipfs-example-plugin
-
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.13
 
 require (
 	github.com/DataDog/datadog-go v4.8.0+incompatible // indirect
+	github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20210527074920-9baf37265e83
 	github.com/ipfs/go-ipfs v0.9.0
 	github.com/ipfs/go-log v1.0.5
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/philhofer/fwd v1.1.1 // indirect
+	go.opencensus.io v0.23.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.31.1
 )

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,16 @@ github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOv
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/datadog-go v3.5.0+incompatible h1:AShr9cqkF+taHjyQgcBcQUt/ZNK+iPq4ROaZwSX5c/U=
+github.com/DataDog/datadog-go v3.5.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.0+incompatible h1:vjzonG+3XzZgYrumNmdrA4QpXju/ZXrwb0mRjpYYbuo=
 github.com/DataDog/datadog-go v4.8.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
+github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20200406135749-5c268882acf0 h1:Y6HFfo8UuntPOpfmUmLb0o3MNYKfUuH2aNmvypsDbY4=
+github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20200406135749-5c268882acf0/go.mod h1:/VV3EFO/hTNQZHAqaj+CPGy2+ioFrP4EX3iRwozubhQ=
+github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20210527074920-9baf37265e83 h1:nP/ZY51AWjudDqYZCNpBzV+pgdURQJ/nQsNVHWMIknQ=
+github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20210527074920-9baf37265e83/go.mod h1:/VV3EFO/hTNQZHAqaj+CPGy2+ioFrP4EX3iRwozubhQ=
 github.com/DataDog/sketches-go v1.0.0 h1:chm5KSXO7kO+ywGWJ0Zs6tdmWU8PBXSbywFVciL6BG4=
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -1251,6 +1257,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
+github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
@@ -1844,6 +1851,9 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/DataDog/dd-trace-go.v1 v1.22.0/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
+gopkg.in/DataDog/dd-trace-go.v1 v1.26.0 h1:Fxt3Z7Nc9NJwqaD5NMOEDANTOT3sUo4gViwFbnqJAfY=
+gopkg.in/DataDog/dd-trace-go.v1 v1.26.0/go.mod h1:Sp1lku8WJMvNV0kjDI4Ni/T7J/U3BO5ct5kEaoVU8+I=
 gopkg.in/DataDog/dd-trace-go.v1 v1.31.1 h1:JvNfQKEqQT0jZyxTlSpHoJLV8A2cJa3ILazZgb5Eor8=
 gopkg.in/DataDog/dd-trace-go.v1 v1.31.1/go.mod h1:wRKMf/tRASHwH/UOfPQ3IQmVFhTz2/1a1/mpXoIjF54=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/plugin/metrics.go
+++ b/plugin/metrics.go
@@ -1,0 +1,43 @@
+package plugin
+
+import (
+	"fmt"
+
+	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
+	"github.com/ipfs/go-ipfs/plugin"
+	"go.opencensus.io/stats/view"
+)
+
+var _ plugin.Plugin = &MetricsPlugin{}
+
+type MetricsPlugin struct {
+	exporter *datadog.Exporter
+}
+
+func (m MetricsPlugin) Name() string {
+	return "datadog-metrics"
+}
+
+func (m MetricsPlugin) Version() string {
+	return "0.0.1"
+}
+
+func (m *MetricsPlugin) Init(env *plugin.Environment) error {
+	dd, err := datadog.NewExporter(datadog.Options{
+		Namespace: "go_ipfs",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create the Datadog exporter: %v", err)
+	}
+
+	m.exporter = dd
+
+	view.RegisterExporter(dd)
+
+	return nil
+}
+
+func (m *MetricsPlugin) Close() error {
+	m.exporter.Stop()
+	return nil
+}

--- a/plugin/plugins.go
+++ b/plugin/plugins.go
@@ -1,0 +1,9 @@
+package plugin
+
+import "github.com/ipfs/go-ipfs/plugin"
+
+var Plugins = []plugin.Plugin{
+	&TracingPlugin{},
+	&LoggerPlugin{},
+	&MetricsPlugin{},
+}

--- a/plugin/tracing.go
+++ b/plugin/tracing.go
@@ -11,14 +11,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
-var log = logging.Logger("datadog")
-
-var Plugins = []plugin.Plugin{
-	&DatadogPlugin{},
-	&LoggerPlugin{},
-}
-
-var _ plugin.PluginTracer = &DatadogPlugin{}
+var _ plugin.PluginTracer = &TracingPlugin{}
 
 var tracerName = "go-ipfs"
 
@@ -26,17 +19,17 @@ type datadogConfig struct {
 	TracerName string
 }
 
-type DatadogPlugin struct{}
+type TracingPlugin struct{}
 
-func (d *DatadogPlugin) Name() string {
+func (d *TracingPlugin) Name() string {
 	return "datadog-tracer"
 }
 
-func (d *DatadogPlugin) Version() string {
+func (d *TracingPlugin) Version() string {
 	return "0.0.1"
 }
 
-func (d *DatadogPlugin) Init(env *plugin.Environment) error {
+func (d *TracingPlugin) Init(env *plugin.Environment) error {
 	if env == nil || env.Config == nil {
 		return nil
 	}
@@ -54,7 +47,7 @@ func (d *DatadogPlugin) Init(env *plugin.Environment) error {
 	return nil
 }
 
-func (d *DatadogPlugin) InitTracer() (opentracing.Tracer, error) {
+func (d *TracingPlugin) InitTracer() (opentracing.Tracer, error) {
 	return opentracer.New(
 		tracer.WithServiceName(tracerName),
 		tracer.WithLogger(logger{}),
@@ -64,10 +57,12 @@ func (d *DatadogPlugin) InitTracer() (opentracing.Tracer, error) {
 	), nil
 }
 
-func (d *DatadogPlugin) Close() error {
+func (d *TracingPlugin) Close() error {
 	tracer.Stop()
 	return nil
 }
+
+var log = logging.Logger("datadog")
 
 // logger is an adaptor between ddtrace.Logger and go-log
 type logger struct{}


### PR DESCRIPTION
This only configure the exporter, which means other system will have to register their metrics on their own with `view.Register()`.

Note: this target go-ipfs v0.7.0, so it will need to be rebased on the final v0.8.0 branch once it's ready.