### PR TITLE
Migrate from Jenkins to GHA

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.28
+          args: "-v"
       - name: Unit Tests
         run: |
           set -o pipefail

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,8 +21,12 @@ jobs:
           go mod download
           go mod vendor
           go get -u github.com/jstemmer/go-junit-report
-          which go-junit-report
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.28
+      - name: Unit Tests
+        run: |
+          set -o pipefail
+          SKIP_E2E=1 go test ./... -v 2>&1 | tee test.log
+          cat test.log | go-junit-report > test-report.xml

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,23 +11,14 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Setup Go
-        uses: actions/setup-go@v3
+      - name: Check out actions
+        uses: actions/checkout@v2
         with:
-          go-version: 1.16.8
-      - name: Install deps
-        run: |
-          export GOPATH=$(go env GOROOT)
-          go mod download
-          go mod vendor
-          go get -u github.com/jstemmer/go-junit-report
-      - name: Lint
-        uses: golangci/golangci-lint-action@v3
+          repository: infura/ghaction-packed
+          token: ${{ secrets.JENKINS_INF_ACTIONS_PRIVATE_REPO_READ_TOKEN }}
+          ref: go-action
+          path: .ghaction-packed
+      - name: Lint and Test
+        uses: ./.ghaction-packed/go/zeroconfig
         with:
-          version: v1.28
-          args: "-v"
-      - name: Unit Tests
-        run: |
-          set -o pipefail
-          SKIP_E2E=1 go test ./... -v 2>&1 | tee test.log
-          cat test.log | go-junit-report > test-report.xml
+          go_version: 1.16.8

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: Lint and Test
         uses: ./.ghaction-packed/go/zeroconfig
         with:
-          go_version: 1.16.8
+          go_version: 1.17

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,0 +1,28 @@
+name: Build and Test
+on:
+  push
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  worflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16.8
+      - name: Install deps
+        run: |
+          export GOPATH=$(go env GOROOT)
+          go mod download
+          go mod vendor
+          go get -u github.com/jstemmer/go-junit-report
+          which go-junit-report
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.28

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,6 +1,9 @@
-name: Build and Test
+name: Lint and Test
 on:
-  push
+  pull_request:
+  push:
+    branches:
+      - master
 permissions:
   id-token: write
   contents: read
@@ -16,7 +19,7 @@ jobs:
         with:
           repository: infura/ghaction-packed
           token: ${{ secrets.JENKINS_INF_ACTIONS_PRIVATE_REPO_READ_TOKEN }}
-          ref: go-action
+          ref: v0.0.3
           path: .ghaction-packed
       - name: Lint and Test
         uses: ./.ghaction-packed/go/zeroconfig

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,0 @@
-infura.goZeroConfig([
-  goModules: true
-])
-


### PR DESCRIPTION
This adds a basic GHA workflow that mimics existing Jenkins workflow, which only performs linting and unit tests.