### PR TITLE
Override default agent address via DD_AGENT_ADDR env var

### DIFF
--- a/plugin/metrics.go
+++ b/plugin/metrics.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"os"
 
 	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
 	"github.com/ipfs/kubo/plugin"
@@ -23,9 +24,15 @@ func (m MetricsPlugin) Version() string {
 }
 
 func (m *MetricsPlugin) Init(env *plugin.Environment) error {
-	dd, err := datadog.NewExporter(datadog.Options{
+	ddOptions := datadog.Options{
 		Namespace: "kubo",
-	})
+	}
+
+	if ddAgentAddr := os.Getenv("DD_AGENT_ADDR"); ddAgentAddr != "" {
+		ddOptions.TraceAddr = ddAgentAddr
+	}
+
+	dd, err := datadog.NewExporter(ddOptions)
 	if err != nil {
 		return fmt.Errorf("failed to create the Datadog exporter: %v", err)
 	}

--- a/plugin/profiler.go
+++ b/plugin/profiler.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/ipfs/kubo/plugin"
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
@@ -33,13 +34,19 @@ func (p *ProfilerPlugin) Init(env *plugin.Environment) error {
 		return err
 	}
 
-	return profiler.Start(
+	profOptions := []profiler.Option{
 		profiler.WithService(p.conf.ProfilerName),
 		profiler.WithProfileTypes(
 			profiler.CPUProfile,
 			profiler.HeapProfile,
 		),
-	)
+	}
+
+	if ddAgentAddr := os.Getenv("DD_AGENT_ADDR"); ddAgentAddr != "" {
+		profOptions = append(profOptions, profiler.WithAgentAddr(ddAgentAddr))
+	}
+
+	return profiler.Start(profOptions...)
 }
 
 func (p *ProfilerPlugin) Close() error {

--- a/plugin/tracing.go
+++ b/plugin/tracing.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"encoding/json"
+	"os"
 
 	logging "github.com/ipfs/go-log"
 	"github.com/ipfs/kubo/plugin"
@@ -35,12 +36,18 @@ func (t *TracingPlugin) Init(env *plugin.Environment) error {
 }
 
 func (t *TracingPlugin) InitTracer() (opentracing.Tracer, error) {
-	return opentracer.New(
+	tracerOptions := []tracer.StartOption{
 		tracer.WithServiceName(t.conf.TracerName),
 		tracer.WithLogger(logger{}),
 		tracer.WithRuntimeMetrics(),
 		tracer.WithAnalytics(true),
-	), nil
+	}
+
+	if ddAgentAddr := os.Getenv("DD_AGENT_ADDR"); ddAgentAddr != "" {
+		tracerOptions = append(tracerOptions, tracer.WithAgentAddr(ddAgentAddr))
+	}
+
+	return opentracer.New(tracerOptions...), nil
 }
 
 func (t *TracingPlugin) Close() error {


### PR DESCRIPTION
In k8s we won't have a local agent anymore.  
There's one for the whole cluster at `datadog-agent.datadog.svc.cluster.local:8126`